### PR TITLE
Added requirement for attrs version 19.1. Needed until the grafanalib…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     license='Apache',
     url='https://github.com/v3io/grafwiz',
     py_modules=['grafwiz'],
-    install_requires=['grafanalib'],
+    install_requires=['attrs==19.1','grafanalib'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',


### PR DESCRIPTION
The grafanalib module is incompatible with the module attrs version 19.3. Until the grafanalib module gets updated, we need to use attrs version 19.1. Change setup.py to satisfy the dependency.