### PR TITLE
Add no-auth datasource

### DIFF
--- a/grafwiz.py
+++ b/grafwiz.py
@@ -319,7 +319,7 @@ class DataSource(object):
     frames_password = attr.ib(default='')
     frames_accesskey = attr.ib(default='')
 
-    def deploy(self, url, user='', password='', overwrite=False):
+    def deploy(self, url, user='', password='', overwrite=False, use_auth=True):
 
         frames_user = self.frames_user or environ.get('V3IO_USERNAME', '')
         frames_password = self.frames_password or environ.get('V3IO_PASSWORD', '')
@@ -334,14 +334,16 @@ class DataSource(object):
                   data=json.dumps(dict(name=self.name,
                                        type='grafana-simple-json-datasource',
                                        url=self.frames_url,
-                                       access='proxy',
-                                       basicAuth=True,
-                                       basicAuthUser=frames_user,
-                                       basicAuthPassword=frames_password)),
+                                       access='proxy'),
                   auth=None,
                   headers={'content-type': 'application/json',
                            'x-remote-user': environ.get('V3IO_USERNAME', 'admin')})
-        if user:
+
+        if use_auth:
+            auth_dict = dict(basicAuth=True, 
+                             basicAuthUser=frames_user,
+                             basicAuthPassword=frames_password)
+            kw['data'].append(auth_dict)
             kw['auth'] = HTTPBasicAuth(user, password)
 
         res = requests.post(**kw)

--- a/grafwiz.py
+++ b/grafwiz.py
@@ -1,6 +1,6 @@
 # extending grafanalib from https://github.com/weaveworks/grafanalib
 
-__version__ = '0.1.0'
+__version__ = "0.1.0"
 
 import json
 import random
@@ -11,8 +11,16 @@ import requests
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import HTTPError
 from requests.status_codes import codes as request_codes
-from grafanalib.core import (Time, Templating, Template, Row, TABLE_TARGET_FORMAT, Target,
-                             single_y_axis, ColumnStyle)
+from grafanalib.core import (
+    Time,
+    Templating,
+    Template,
+    Row,
+    TABLE_TARGET_FORMAT,
+    Target,
+    single_y_axis,
+    ColumnStyle,
+)
 from grafanalib._gen import DashboardEncoder
 from attr.validators import instance_of
 from os import environ
@@ -25,7 +33,7 @@ class ExtendedTarget(Target):
 
     def to_json_data(self):
         retval = super(ExtendedTarget, self).to_json_data()
-        retval['type'] = self.type
+        retval["type"] = self.type
         return retval
 
 
@@ -37,26 +45,28 @@ class DashboardImport(object):
 
     def to_json_data(self):
         return {
-            'dashboard': self.dashboard,
-            'inputs': self.inputs,
-            'overwrite': self.overwrite,
+            "dashboard": self.dashboard,
+            "inputs": self.inputs,
+            "overwrite": self.overwrite,
         }
 
 
 @attr.s
 class ExtendedColumnStyle(ColumnStyle):
     link = attr.ib(validator=instance_of(bool), default=False)
-    link_url = attr.ib('')
-    link_tooltip = attr.ib('')
+    link_url = attr.ib("")
+    link_tooltip = attr.ib("")
 
     def to_json_data(self):
         retval = super(ExtendedColumnStyle, self).to_json_data()
         if self.link:
-            retval.update({
-                'link': self.link,
-                'linkUrl': self.link_url,
-                'linkTooltip': self.link_tooltip
-            })
+            retval.update(
+                {
+                    "link": self.link,
+                    "linkUrl": self.link_url,
+                    "linkTooltip": self.link_tooltip,
+                }
+            )
         return retval
 
 
@@ -73,7 +83,6 @@ class Ajax(object):
     :param mode: defines the display mode (json)
     :param method: http method GET/POST/iframe
     """
-
 
     dataSource = attr.ib(default=None)
     targets = attr.ib(default=attr.Factory(list))
@@ -98,28 +107,30 @@ class Ajax(object):
 
     def to_json_data(self):
         return {
-            'dataSource': self.dataSource,
-            'targets': self.targets,
-            'title': self.title,
-            'editable': self.editable,
-            'id': self.id,
-            'links': self.links,
-            'showTime': self.showTime,
-            'responseType': self.responseType,
-            'params_js': self.params_js,
-            'showTimeFormat': self.showTimeFormat,
-            'showTimePrefix': self.showTimePrefix,
-            'showTimeValue': self.showTimeValue,
-            'skipSameURL': self.skipSameURL,
-            'method': self.method,
-            'mode': self.mode,
-            'withCredentials': self.withCredentials,
-            'url': self.url,
-            'template': self.template,
-            'type': "ryantxu-ajax-panel"
+            "dataSource": self.dataSource,
+            "targets": self.targets,
+            "title": self.title,
+            "editable": self.editable,
+            "id": self.id,
+            "links": self.links,
+            "showTime": self.showTime,
+            "responseType": self.responseType,
+            "params_js": self.params_js,
+            "showTimeFormat": self.showTimeFormat,
+            "showTimePrefix": self.showTimePrefix,
+            "showTimeValue": self.showTimeValue,
+            "skipSameURL": self.skipSameURL,
+            "method": self.method,
+            "mode": self.mode,
+            "withCredentials": self.withCredentials,
+            "url": self.url,
+            "template": self.template,
+            "type": "ryantxu-ajax-panel",
         }
 
-_query_separator = ';'
+
+_query_separator = ";"
+
 
 @attr.s
 class Dashboard(gf.Dashboard):
@@ -132,24 +143,24 @@ class Dashboard(gf.Dashboard):
     """
 
     rows = attr.ib(default=attr.Factory(list))
-    start = attr.ib(default='now-1h')
-    end = attr.ib(default='now')
+    start = attr.ib(default="now-1h")
+    end = attr.ib(default="now")
     templates = attr.ib(default=attr.Factory(list))
-    dataSource = attr.ib(default='iguazio')
-    backend = attr.ib(default='')
-    container = attr.ib(default='')
+    dataSource = attr.ib(default="iguazio")
+    backend = attr.ib(default="")
+    container = attr.ib(default="")
 
     def row(self, elements=None, **kw):
         elements = elements or []
         panels = []
         for element in elements:
-            element.dataSource = getattr(element, 'dataSource', '') or self.dataSource
+            element.dataSource = getattr(element, "dataSource", "") or self.dataSource
             panels += [element]
         self.rows += [Row(panels=panels, **kw)]
         return self
 
-    def template(self, name, frame=None, type='query', query='', **kw):
-        kw['dataSource'] = getattr(kw, 'dataSource', '') or self.dataSource
+    def template(self, name, frame=None, type="query", query="", **kw):
+        kw["dataSource"] = getattr(kw, "dataSource", "") or self.dataSource
         if frame and not query:
             query = frame.gen_target
         self.templates += [Template(name=name, type=type, query=query, **kw)]
@@ -158,57 +169,65 @@ class Dashboard(gf.Dashboard):
     def show(self):
         return self.__generate()
 
-    def deploy(self, url, user='', password=''):
+    def deploy(self, url, user="", password=""):
 
         auth = None
         if user:
             auth = HTTPBasicAuth(user, password)
 
-        res = requests.post(url='{}/api/dashboards/import'.format(url),
-                            data=self.__generate(),
-                            auth=auth,
-                            headers={'Content-Type': 'application/json;charset=UTF-8',
-                                     'x-remote-user': environ.get('V3IO_USERNAME', 'admin')})
+        res = requests.post(
+            url="{}/api/dashboards/import".format(url),
+            data=self.__generate(),
+            auth=auth,
+            headers={
+                "Content-Type": "application/json;charset=UTF-8",
+                "x-remote-user": environ.get("V3IO_USERNAME", "admin"),
+            },
+        )
         res.raise_for_status()
-        print('Dashboard {} created successfully'.format(self.title))
+        print("Dashboard {} created successfully".format(self.title))
 
     def __generate(self):
 
-        self.uid = ''.join(random.choice(ascii_lowercase + digits) for _ in range(10))
+        self.uid = "".join(random.choice(ascii_lowercase + digits) for _ in range(10))
         self.time = Time(start=self.start, end=self.end)
-        self.templating=Templating(self.templates)
+        self.templating = Templating(self.templates)
         dashboard = self.auto_panel_ids()
 
         dashboard_import = DashboardImport(dashboard=dashboard)
-        return json.dumps(dashboard_import.to_json_data(),
-                            sort_keys=True,
-                            indent=2,
-                            cls=DashboardEncoder)
-
+        return json.dumps(
+            dashboard_import.to_json_data(),
+            sort_keys=True,
+            indent=2,
+            cls=DashboardEncoder,
+        )
 
 
 @attr.s
 class DataFrame(object):
 
     backend = attr.ib()
-    container = attr.ib(default='')
-    query = attr.ib(default='')
-    table = attr.ib(default='')
-    filter = attr.ib(default='')
+    container = attr.ib(default="")
+    query = attr.ib(default="")
+    table = attr.ib(default="")
+    filter = attr.ib(default="")
     fields = attr.ib(default=[])
 
     def gen_target(self):
-        target = ['table='+self.table,
-                  'fields={}'.format(','.join(self.fields)),'backend='+ self.backend, 'container='+ self.container]
+        target = [
+            "table=" + self.table,
+            "fields={}".format(",".join(self.fields)),
+            "backend=" + self.backend,
+            "container=" + self.container,
+        ]
 
         if self.filter:
-            target += ['filter='+self.filter]
+            target += ["filter=" + self.filter]
 
         if self.query:
-            target += ['query='+self.query]
+            target += ["query=" + self.query]
 
         return _query_separator.join(target)
-
 
 
 @attr.s
@@ -239,20 +258,22 @@ class Table(gf.Table):
     :param transparent: defines if panel should be transparent
     """
 
-    dataSource = attr.ib(default='')
+    dataSource = attr.ib(default="")
     targets = attr.ib(default=[])
-    transform = attr.ib(default='table_to_columns')
+    transform = attr.ib(default="table_to_columns")
 
     def source(self, **kw):
-        kw['backend'] = getattr(kw, 'backend', 'kv')
-        self.targets.append(ExtendedTarget(
-                            expr='',
-                            legendFormat="1xx",
-                            refId=random.choice(ascii_uppercase),
-                            target=DataFrame(**kw).gen_target(),
-                            format=TABLE_TARGET_FORMAT,
-                            type='table'
-                        ))
+        kw["backend"] = getattr(kw, "backend", "kv")
+        self.targets.append(
+            ExtendedTarget(
+                expr="",
+                legendFormat="1xx",
+                refId=random.choice(ascii_uppercase),
+                target=DataFrame(**kw).gen_target(),
+                format=TABLE_TARGET_FORMAT,
+                type="table",
+            )
+        )
         return self
 
 
@@ -284,81 +305,104 @@ class Graph(gf.Graph):
     def yaxis(self, **kw):
         self.yAxes = gf.YAxes(left=gf.YAxis(**kw))
 
-    def series(self, expr='', legendFormat='1xx', **kw):
+    def series(self, expr="", legendFormat="1xx", **kw):
 
         ref_id = ascii_uppercase[self._last_target]
         self._last_target += 1
 
         if expr:
-            self.targets = [ExtendedTarget(
-                expr=expr,
-                format="time_series",
-                refId=ref_id,
-                legendFormat=legendFormat,
-                type='timeserie')]
+            self.targets = [
+                ExtendedTarget(
+                    expr=expr,
+                    format="time_series",
+                    refId=ref_id,
+                    legendFormat=legendFormat,
+                    type="timeserie",
+                )
+            ]
         else:
 
-            kw['backend'] = getattr(kw,'backend', 'tsdb')
+            kw["backend"] = getattr(kw, "backend", "tsdb")
 
-            self.targets = [ExtendedTarget(
-                expr='',
-                format="time_series",
-                target=DataFrame(**kw).gen_target(),
-                refId=ref_id,
-                legendFormat=legendFormat,
-                type='timeserie')]
+            self.targets = [
+                ExtendedTarget(
+                    expr="",
+                    format="time_series",
+                    target=DataFrame(**kw).gen_target(),
+                    refId=ref_id,
+                    legendFormat=legendFormat,
+                    type="timeserie",
+                )
+            ]
 
         return self
+
 
 @attr.s
 class DataSource(object):
 
-    name = attr.ib(default='iguazio')
-    frames_url = attr.ib(default='http://framesd:8080')
-    frames_user = attr.ib(default='')
-    frames_password = attr.ib(default='')
-    frames_accesskey = attr.ib(default='')
+    name = attr.ib(default="iguazio")
+    frames_url = attr.ib(default="http://framesd:8080")
+    frames_user = attr.ib(default="")
+    frames_password = attr.ib(default="")
+    frames_accesskey = attr.ib(default="")
 
-    def deploy(self, url, user='', password='', overwrite=False, use_auth=True):
+    def deploy(self, url, user="", password="", overwrite=False, use_auth=True):
 
-        frames_user = self.frames_user or environ.get('V3IO_USERNAME', '')
-        frames_password = self.frames_password or environ.get('V3IO_PASSWORD', '')
-        frames_accesskey = self.frames_accesskey or environ.get('V3IO_ACCESS_KEY', '')
+        frames_user = self.frames_user or environ.get("V3IO_USERNAME", "")
+        frames_password = self.frames_password or environ.get("V3IO_PASSWORD", "")
+        frames_accesskey = self.frames_accesskey or environ.get("V3IO_ACCESS_KEY", "")
         if frames_accesskey and not frames_password:
             # in case of access key we use fake user account __ACCESS_KEY in basic auth
-            frames_user = '__ACCESS_KEY'
+            frames_user = "__ACCESS_KEY"
             frames_password = frames_accesskey
 
-        kw = dict(url='{}/api/datasources'.format(url),
-                  verify=False,
-                  data=json.dumps(dict(name=self.name,
-                                       type='grafana-simple-json-datasource',
-                                       url=self.frames_url,
-                                       access='proxy'),
-                  auth=None,
-                  headers={'content-type': 'application/json',
-                           'x-remote-user': environ.get('V3IO_USERNAME', 'admin')})
+        kw = dict(
+            url="{}/api/datasources".format(url),
+            verify=False,
+            data=json.dumps(
+                dict(
+                    name=self.name,
+                    type="grafana-simple-json-datasource",
+                    url=self.frames_url,
+                    access="proxy",
+                )
+            ),
+            auth=None,
+            headers={
+                "content-type": "application/json",
+                "x-remote-user": environ.get("V3IO_USERNAME", "admin"),
+            },
+        )
 
         if use_auth:
-            auth_dict = dict(basicAuth=True, 
-                             basicAuthUser=frames_user,
-                             basicAuthPassword=frames_password)
-            kw['data'].append(auth_dict)
-            kw['auth'] = HTTPBasicAuth(user, password)
+            auth_dict = dict(
+                basicAuth=True,
+                basicAuthUser=frames_user,
+                basicAuthPassword=frames_password,
+            )
+            kw["data"].append(auth_dict)
+            kw["auth"] = HTTPBasicAuth(user, password)
 
         res = requests.post(**kw)
         try:
             res.raise_for_status()
         except HTTPError:
             if res.status_code == request_codes.conflict:
-                print('Datasource {} already exists'.format(self.name))
+                print("Datasource {} already exists".format(self.name))
                 if overwrite:
-                    print('Recreating datasource {}'.format(self.name))
-                    res = requests.delete(url='{}/api/datasources/name/{}'.format(self.__grafana_url, self.name), verify=False,
-                                          auth=HTTPBasicAuth(*self.__auth))
+                    print("Recreating datasource {}".format(self.name))
+                    res = requests.delete(
+                        url="{}/api/datasources/name/{}".format(
+                            self.__grafana_url, self.name
+                        ),
+                        verify=False,
+                        auth=HTTPBasicAuth(*self.__auth),
+                    )
                     res.raise_for_status()
                     res = requests.post(**kw)
                     res.raise_for_status()
             else:
                 raise
-        print('Datasource {} created successfully'.format(self.name))
+        print("Datasource {} created successfully".format(self.name))
+


### PR DESCRIPTION
By adding `use_auth` flag on the `DataSource().deploy()` you can now choose to not-add an httpauth for enabling non-framesd datasources depyloyments.